### PR TITLE
Footer for smartphone/tablet

### DIFF
--- a/app/(footer)/Footer.module.css
+++ b/app/(footer)/Footer.module.css
@@ -17,6 +17,7 @@
 @media screen and (max-width: 959px) {
 	.footer{
 		height: auto;
+		padding-top: 30px;
 		padding-bottom: 35px;
 		display: block;
 	}

--- a/app/(footer)/Footer.module.css
+++ b/app/(footer)/Footer.module.css
@@ -16,7 +16,8 @@
 
 @media screen and (max-width: 959px) {
 	.footer{
-		height: 800px;
+		height: auto;
+		padding-bottom: 35px;
 		display: block;
 	}
 

--- a/app/(footer)/Footer.module.css
+++ b/app/(footer)/Footer.module.css
@@ -13,3 +13,15 @@
 	width: 45%;
 	margin-right: 30px;
 }
+
+@media screen and (max-width: 700px) {
+	.footer{
+		height: 800px;
+		display: block;
+	}
+
+	.pageInfo {
+		width: 80%;
+		margin: 0 auto;
+	}
+}

--- a/app/(footer)/Footer.module.css
+++ b/app/(footer)/Footer.module.css
@@ -14,7 +14,7 @@
 	margin-right: 30px;
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 959px) {
 	.footer{
 		height: 800px;
 		display: block;

--- a/app/(footer)/Footer.module.css
+++ b/app/(footer)/Footer.module.css
@@ -14,7 +14,7 @@
 	margin-right: 30px;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 480px) {
 	.footer{
 		height: 800px;
 		display: block;

--- a/app/(footer)/GroupInfo.module.css
+++ b/app/(footer)/GroupInfo.module.css
@@ -11,6 +11,7 @@
 .subtitle {
     font-size: 20px;
     margin-top: 0;
+    word-break: keep-all;
 }
 
 .text {

--- a/app/(footer)/GroupInfo.module.css
+++ b/app/(footer)/GroupInfo.module.css
@@ -22,7 +22,10 @@
     .container {
         width: 290px;
         margin: 0 auto;
-        padding-top: 1px;
+    }
+
+    .title {
+        margin-top: 0;
     }
 }
 
@@ -30,11 +33,11 @@
     .container {
         width: 60%;
         margin: 0 auto;
-        padding-top: 1px;
     }
 
     .title {
         font-size: 40px;
+        margin-top: 0;
     }
 
     .subtitle {

--- a/app/(footer)/GroupInfo.module.css
+++ b/app/(footer)/GroupInfo.module.css
@@ -16,3 +16,19 @@
 .text {
     font-size: 14px;
 }
+
+@media screen and (max-width:700px) {
+    .container {
+        width: 60%;
+        margin: 0 auto;
+        padding-top: 1px;
+    }
+
+    .title {
+        font-size: 40px;
+    }
+
+    .subtitle {
+        font-size: 18px;
+    }
+}

--- a/app/(footer)/GroupInfo.module.css
+++ b/app/(footer)/GroupInfo.module.css
@@ -18,6 +18,14 @@
     font-size: 14px;
 }
 
+@media screen and (min-width: 481px) and (max-width: 959px) {
+    .container {
+        width: 290px;
+        margin: 0 auto;
+        padding-top: 1px;
+    }
+}
+
 @media screen and (max-width:480px) {
     .container {
         width: 60%;

--- a/app/(footer)/GroupInfo.module.css
+++ b/app/(footer)/GroupInfo.module.css
@@ -17,7 +17,7 @@
     font-size: 14px;
 }
 
-@media screen and (max-width:700px) {
+@media screen and (max-width:480px) {
     .container {
         width: 60%;
         margin: 0 auto;

--- a/app/(footer)/GroupInfo.tsx
+++ b/app/(footer)/GroupInfo.tsx
@@ -4,7 +4,7 @@ export default function GroupInfo() {
   return (
     <div className={style.container}>
       <h2 className={style.title}>ALOHA</h2>
-      <h3 className={style.subtitle}>沖縄から東大を、日常に</h3>
+      <h3 className={style.subtitle}>沖縄から東大を、<wbr />日常に</h3>
       <p className={style.text}>お問い合わせ：080-1234-1234（伊礼）</p>
     </div>
   );

--- a/app/(footer)/PageInfo.module.css
+++ b/app/(footer)/PageInfo.module.css
@@ -24,3 +24,20 @@
     font-size: 15px;
     font-weight: bold;
 }
+
+@media screen and (max-width: 700px) {
+    .title {
+        font-size: 18px;
+    }
+
+    .hr {
+        width: 75%;
+        margin: auto;
+        border: 0.5px solid var(--color-white);
+    }
+
+    .text {
+        font-size: 14px;
+        font-weight: medium;
+    }
+}

--- a/app/(footer)/PageInfo.module.css
+++ b/app/(footer)/PageInfo.module.css
@@ -25,15 +25,28 @@
     font-weight: bold;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (min-width: 481px) and (max-width: 959px) {
+    .title {
+        font-size: 20px;
+    }
+
+    .hr {
+        width: 75%;
+    }
+
+    .text {
+        font-size: 15px;
+        font-weight: medium;
+    }
+}
+
+@media screen and (max-width: 480px) {
     .title {
         font-size: 18px;
     }
 
     .hr {
         width: 75%;
-        margin: auto;
-        border: 0.5px solid var(--color-white);
     }
 
     .text {

--- a/app/(footer)/SiteMapcard.module.css
+++ b/app/(footer)/SiteMapcard.module.css
@@ -20,6 +20,21 @@
     padding-bottom: 30px;
 }
 
+@media screen and (min-width: 481px) and (max-width: 959px) {
+    .card {
+        margin: 35px auto;
+        width: 340px;
+        padding-top: 1px;
+        height: 220px;
+    }
+    .border {
+        height: 180px;
+    }
+    .list {
+        padding-bottom: 10px;
+    }
+}
+
 @media screen and (max-width: 480px) {
     .card {
         margin: 35px auto;
@@ -28,7 +43,6 @@
         height: 220px;
     }
     .border {
-        margin: 20px;
         height: 180px;
     }
     .list {

--- a/app/(footer)/SiteMapcard.module.css
+++ b/app/(footer)/SiteMapcard.module.css
@@ -22,7 +22,7 @@
 
 @media screen and (min-width: 481px) and (max-width: 959px) {
     .card {
-        margin: 35px auto;
+        margin: 35px auto 0;
         width: 340px;
         padding-top: 1px;
         height: 220px;
@@ -37,7 +37,7 @@
 
 @media screen and (max-width: 480px) {
     .card {
-        margin: 35px auto;
+        margin: 35px auto 0;
         width: 70%;
         padding-top: 1px;
         height: 220px;

--- a/app/(footer)/SiteMapcard.module.css
+++ b/app/(footer)/SiteMapcard.module.css
@@ -24,10 +24,11 @@
     .card {
         margin: 35px auto 0;
         width: 340px;
-        padding-top: 1px;
-        height: 220px;
+        height: auto;
+        padding: 20px;
     }
     .border {
+        margin: 0;
         height: 180px;
     }
     .list {
@@ -39,10 +40,11 @@
     .card {
         margin: 35px auto 0;
         width: 70%;
-        padding-top: 1px;
-        height: 220px;
+        height: auto;
+        padding: 20px;
     }
     .border {
+        margin: 0;
         height: 180px;
     }
     .list {

--- a/app/(footer)/SiteMapcard.module.css
+++ b/app/(footer)/SiteMapcard.module.css
@@ -19,3 +19,19 @@
     padding-top: 20px;
     padding-bottom: 30px;
 }
+
+@media screen and (max-width: 700px) {
+    .card {
+        margin: 35px auto;
+        width: 70%;
+        padding-top: 1px;
+        height: 220px;
+    }
+    .border {
+        margin: 20px;
+        height: 180px;
+    }
+    .list {
+        padding-bottom: 10px;
+    }
+}

--- a/app/(footer)/SiteMapcard.module.css
+++ b/app/(footer)/SiteMapcard.module.css
@@ -20,7 +20,7 @@
     padding-bottom: 30px;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 480px) {
     .card {
         margin: 35px auto;
         width: 70%;


### PR DESCRIPTION
footerをスマホやタブレットに対応させました。

- marginの相殺を防ぐために、1pxのpaddingを挿入していた部分は、margin/paddingの構成を変えることで挿入しなくても正しく表示されるようにしました。
- 480、959をブレイクポイントとしました。（webサイトによって推奨が異なり、どれが良いかわからなかったので、仮にこの数値にしています）