### PR TITLE
footerの電話番号の改行位置を指定

### DIFF
--- a/app/(footer)/GroupInfo.module.css
+++ b/app/(footer)/GroupInfo.module.css
@@ -18,6 +18,10 @@
     font-size: 14px;
 }
 
+.sp_br {
+    display: none;
+}
+
 @media screen and (min-width: 481px) and (max-width: 959px) {
     .container {
         width: 290px;
@@ -42,5 +46,9 @@
 
     .subtitle {
         font-size: 18px;
+    }
+
+    .sp_br {
+        display: block;
     }
 }

--- a/app/(footer)/GroupInfo.tsx
+++ b/app/(footer)/GroupInfo.tsx
@@ -5,7 +5,7 @@ export default function GroupInfo() {
     <div className={style.container}>
       <h2 className={style.title}>ALOHA</h2>
       <h3 className={style.subtitle}>沖縄から東大を、<wbr />日常に</h3>
-      <p className={style.text}>お問い合わせ：080-1234-1234（伊礼）</p>
+      <p className={style.text}>お問い合わせ：<br className={style.sp_br}/>080-1234-1234（伊礼）</p>
     </div>
   );
 }


### PR DESCRIPTION
スマホ画面ではfooter内の連絡先が
```
お問い合わせ：
080-1234-1234（伊礼）
```
と表示されるようにした。
brタグも、cssのdisplayプロパティをnoneまたはblockにすることで切り替えられる。