### PR TITLE
Documentsをスマホとタブレットに対応

### DIFF
--- a/app/documents/Document.module.css
+++ b/app/documents/Document.module.css
@@ -41,3 +41,18 @@
     width: 50%;
     margin: 30px auto 0;
 }
+
+@media screen and (max-width: 480px) {
+    .container {
+        width: 70%;
+        display: block;
+    }
+
+    .description {
+        margin-top: 30px;
+    }
+
+    .text {
+        font-size: 15px;
+    }
+}

--- a/app/documents/Document.module.css
+++ b/app/documents/Document.module.css
@@ -42,6 +42,17 @@
     margin: 30px auto 0;
 }
 
+@media screen and (min-width: 481px) and (max-width: 959px){
+    .container {
+        width: 60%;
+        display: block;
+    }
+
+    .description {
+        margin-top: 40px;
+    }
+}
+
 @media screen and (max-width: 480px) {
     .container {
         width: 70%;


### PR DESCRIPTION
documentsをスマホとタブレットに対応させました。
- タブレット場合の「閲覧はこちら」と「ダウンロードはこちら」が左に寄りすぎな気がしますが、文章の量が増えると違和感がなくなるかもと思い、放置しています。